### PR TITLE
Use by_def_Col_from instead of one_of_disjunct

### DIFF
--- a/by_prop_OppositeSide_symmetric.v
+++ b/by_prop_OppositeSide_symmetric.v
@@ -1,8 +1,8 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_OppositeSide.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
-Require Import ProofCheckingEuclid.by_prop_Col_order.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
 Require Import ProofCheckingEuclid.by_prop_nCol_distinct.
 Require Import ProofCheckingEuclid.by_prop_nCol_order.
@@ -32,7 +32,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_P_R_Q) as (neq_R_Q & _ & _).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_Q_R_P) as (_ & neq_Q_R & neq_Q_P).
 
-	assert (Col P R Q) as Col_P_R_Q by (unfold Col; one_of_disjunct BetS_P_R_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_P_R_Q) as Col_P_R_Q.
 
 	pose proof (by_prop_Col_order _ _ _ Col_P_R_Q) as (_ & _ & _ & _ & Col_Q_R_P).
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_R) as (_ & _ & _ & _ & Col_R_B_A).

--- a/by_prop_RightTriangle_NC.v
+++ b/by_prop_RightTriangle_NC.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_Midpoint.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
@@ -34,7 +35,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_B_D) as (_ & neq_A_B & neq_A_D).
 	pose proof (by_prop_neq_symmetric _ _ neq_A_B) as neq_B_A.
 
-	assert (Col A B D) as Col_A_B_D by (unfold Col; one_of_disjunct BetS_A_B_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_B_D) as Col_A_B_D.
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_D) as (Col_B_A_D & _ & _ & _ & _).
 
 	pose proof (by_prop_Cong_flip _ _ _ _ Cong_AB_DB) as (_ & _ & Cong_AB_BD).

--- a/by_prop_RightTriangle_symmetric.v
+++ b/by_prop_RightTriangle_symmetric.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
 Require Import ProofCheckingEuclid.by_def_RightTriangle.
 Require Import ProofCheckingEuclid.by_def_Supp.
@@ -57,7 +58,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_B_E) as (neq_B_E & _ & _).
 	pose proof (by_prop_neq_symmetric _ _ neq_B_E) as neq_E_B.
 
-	assert (Col C B E) as Col_C_B_E by (unfold Col; one_of_disjunct BetS_C_B_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_B_E) as Col_C_B_E.
 	pose proof (by_prop_Col_order _ _ _ Col_C_B_E) as (_ & _ & _ & _ & Col_E_B_C).
 
 	pose proof (by_def_Supp _ _ _ _ _ OnRay_BC_C BetS_A_B_D) as Supp_ABC_CBD.

--- a/lemma_angletrichotomy.v
+++ b/lemma_angletrichotomy.v
@@ -1,4 +1,6 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_eq_A_B.
 Require Import ProofCheckingEuclid.by_def_OppositeSide.
 Require Import ProofCheckingEuclid.by_def_SameSide.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -50,7 +52,7 @@ Proof.
 		pose proof (by_prop_neq_symmetric _ _ neq_G_H) as neq_H_G.
 		pose proof (by_prop_neq_symmetric _ _ neq_J_H) as neq_H_J.
 
-		assert (Col G H J) as Col_G_H_J by (unfold Col; one_of_disjunct BetS_G_H_J).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_G_H_J) as Col_G_H_J.
 		pose proof (by_prop_Col_order _ _ _ Col_G_H_J) as (_ & Col_H_J_G & _ & _ & _).
 
 		pose proof (by_prop_OnRay_neq_A_C _ _ _ OnRay_BA_G) as neq_B_G.
@@ -127,7 +129,7 @@ Proof.
 			assert (BetS G B J) as BetS_G_B_J by (rewrite <- eq_H_B; exact BetS_G_H_J).
 			pose proof (by_prop_BetS_notequal _ _ _ BetS_G_B_J) as (_ & _ & neq_G_J).
 
-			assert (Col G B J) as Col_G_B_J by (unfold Col; one_of_disjunct BetS_G_B_J).
+			pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_G_B_J) as Col_G_B_J.
 			pose proof (by_prop_Col_order _ _ _ Col_G_B_J) as (Col_B_G_J & _ & _ & Col_G_J_B & _).
 
 			pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_B_G_J Col_B_G_A neq_B_G) as Col_G_J_A.
@@ -149,7 +151,7 @@ Proof.
 		pose proof (by_def_SameSide _ _ _ _ _ _ _ Col_B_U_G Col_B_U_G BetS_J_G_P BetS_H_G_P nCol_B_U_J nCol_B_U_H) as SameSide_J_H_BU.
 		pose proof (by_prop_SameSide_symmetric _ _ _ _ SameSide_J_H_BU) as (SameSide_H_J_BU & _ & _).
 		assert (eq B B) as eq_B_B by (reflexivity).
-		assert (Col B B U) as Col_B_B_U by (unfold Col; one_of_disjunct eq_B_B).
+		pose proof (by_def_Col_from_eq_A_B B B U eq_B_B) as Col_B_B_U.
 		pose proof (lemma_sameside_onray _ _ _ _ _ _ SameSide_H_J_BU Col_B_B_U OnRay_BJ_V) as SameSide_H_V_BU.
 		pose proof (by_prop_SameSide_symmetric _ _ _ _ SameSide_H_V_BU) as (SameSide_V_H_BU & _ & _).
 		pose proof (lemma_sameside_onray _ _ _ _ _ _ SameSide_V_H_BU Col_B_B_U OnRay_BH_v) as SameSide_V_v_BU.

--- a/lemma_crossbar.v
+++ b/lemma_crossbar.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_Lt.
 Require Import ProofCheckingEuclid.by_def_OnRay.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -57,8 +58,8 @@ Proof.
 	pose proof (by_prop_Cong_symmetric _ _ _ _ Cong_AP_BU) as Cong_BU_AP.
 	pose proof (by_prop_Cong_symmetric _ _ _ _ Cong_CQ_BV) as Cong_BV_CQ.
 
-	assert (Col B A P) as Col_B_A_P by (unfold Col; one_of_disjunct BetS_B_A_P).
-	assert (Col B C Q) as Col_B_C_Q by (unfold Col; one_of_disjunct BetS_B_C_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_A_P) as Col_B_A_P.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_C_Q) as Col_B_C_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_B_A_P) as (_ & _ & Col_P_B_A & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_B_C_Q) as (_ & _ & Col_Q_B_C & _ & _).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_B_A_P) as (_ & _ & neq_B_P).
@@ -120,7 +121,7 @@ Proof.
 	pose proof (postulate_Pasch_inner _ _ _ _ _ BetS_Q_W_P BetS_B_U_P nCol_Q_P_B) as (M & BetS_Q_M_U & BetS_B_M_W).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_Q_M_U) as BetS_U_M_Q.
 
-	assert (Col B U P) as Col_B_U_P by (unfold Col; one_of_disjunct BetS_B_U_P).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_U_P) as Col_B_U_P.
 	pose proof (by_prop_Col_order _ _ _ Col_B_U_P) as (_ & _ & _ & Col_B_P_U & _).
 	pose proof (lemma_s_ncol_ABD_col_ABC_ncol_ACD _ _ _ _ nCol_B_P_Q Col_B_P_U neq_B_U) as nCol_B_U_Q.
 	pose proof (by_prop_nCol_order _ _ _ nCol_B_U_Q) as (_ & nCol_U_Q_B & _ & _ & _).

--- a/lemma_droppedperpendicularunique.v
+++ b/lemma_droppedperpendicularunique.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_Midpoint.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
@@ -58,7 +59,7 @@ Proof.
 
 		pose proof (by_prop_Cong_flip _ _ _ _ Cong_MF_ME) as (_ & Cong_FM_ME & _ ).
 
-		assert (Col J M F) as Col_J_M_F by (unfold Col; one_of_disjunct BetS_J_M_F).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_J_M_F) as Col_J_M_F.
 		pose proof (by_prop_Col_order _ _ _ Col_J_M_F) as (Col_M_J_F & _ & _ & _ & _).
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_M_J_F Col_M_J_A neq_M_J) as Col_J_F_A.

--- a/lemma_oppositeside_betweenness_PABC_RPQ_QABC.v
+++ b/lemma_oppositeside_betweenness_PABC_RPQ_QABC.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
@@ -39,7 +40,7 @@ Proof.
 
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_P_S_C) as BetS_C_S_P.
 	pose proof (postulate_Pasch_outer _ _ _ _ _ BetS_C_S_P BetS_R_P_Q nCol_R_Q_C) as (F & BetS_C_F_Q & BetS_R_S_F).
-	assert (Col R S F) as Col_R_S_F by (unfold Col; one_of_disjunct BetS_R_S_F).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_R_S_F) as Col_R_S_F.
 	pose proof (by_prop_nCol_distinct _ _ _ nCol_A_B_P) as (neq_A_B & _ & _ & neq_B_A & _).
 	pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_A_B_R Col_A_B_S neq_A_B) as Col_B_R_S.
 	pose proof (by_prop_Col_order _ _ _ Col_B_R_S) as (Col_R_B_S & Col_R_S_B & Col_S_B_R & Col_B_S_R & Col_S_R_B).
@@ -95,7 +96,7 @@ Proof.
 		}
 		pose proof (by_prop_Col_order _ _ _ Col_R_Q_F) as (Col_Q_R_F & Col_Q_F_R & Col_F_R_Q & Col_R_F_Q & Col_F_Q_R).
 
-		assert (Col C F Q) as Col_C_F_Q by (unfold Col; one_of_disjunct BetS_C_F_Q).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_F_Q) as Col_C_F_Q.
 		pose proof (by_prop_Col_order _ _ _ Col_C_F_Q) as (Col_F_C_Q & Col_F_Q_C & Col_Q_C_F & Col_C_Q_F & Col_Q_F_C).
 		pose proof (by_prop_BetS_notequal _ _ _ BetS_C_F_Q) as (neq_F_Q & neq_C_F & neq_C_Q).
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_F_Q_R Col_F_Q_C neq_F_Q) as Col_Q_R_C.

--- a/lemma_oppositeside_betweenness_PABC_RQP_QABC.v
+++ b/lemma_oppositeside_betweenness_PABC_RQP_QABC.v
@@ -1,4 +1,6 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_C_B.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
@@ -37,7 +39,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_R_Q_P) as (neq_Q_P & neq_R_Q & neq_R_P). (* wanted neq_R_S *)
 
 	pose proof (postulate_Pasch_inner _ _ _ _ _ BetS_C_S_P BetS_R_Q_P nCol_C_P_R) as (F & BetS_C_F_Q & BetS_R_F_S).
-	assert (Col R S F) as Col_R_S_F by (unfold Col; one_of_disjunct BetS_R_F_S).
+	pose proof (by_def_Col_from_BetS_A_C_B _ _ _ BetS_R_F_S) as Col_R_S_F.
 	pose proof (by_prop_nCol_distinct _ _ _ nCol_A_B_P) as (neq_A_B & _ & _ & neq_B_A & _).
 	pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_A_B_R Col_A_B_S neq_A_B) as Col_B_R_S.
 	pose proof (by_prop_Col_order _ _ _ Col_B_R_S) as (Col_R_B_S & Col_R_S_B & Col_S_B_R & Col_B_S_R & Col_S_R_B). (* wanted Col_R_S_B *)
@@ -92,14 +94,14 @@ Proof.
 		}
 		pose proof (by_prop_Col_order _ _ _ Col_R_Q_F) as (Col_Q_R_F & Col_Q_F_R & Col_F_R_Q & Col_R_F_Q & Col_F_Q_R).
 
-		assert (Col C F Q) as Col_C_F_Q by (unfold Col; one_of_disjunct BetS_C_F_Q).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_F_Q) as Col_C_F_Q.
 
 		pose proof (by_prop_Col_order _ _ _ Col_C_F_Q) as (Col_F_C_Q & Col_F_Q_C & Col_Q_C_F & Col_C_Q_F & Col_Q_F_C).
 		pose proof (by_prop_BetS_notequal _ _ _ BetS_C_F_Q) as (neq_F_Q & neq_C_F & neq_C_Q).
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_F_Q_R Col_F_Q_C neq_F_Q) as Col_Q_R_C.
 		pose proof (by_prop_Col_order _ _ _ Col_Q_R_C) as (Col_R_Q_C & Col_R_C_Q & Col_C_Q_R & Col_Q_C_R & Col_C_R_Q).
 
-		assert (Col R Q P) as Col_R_Q_P by (unfold Col; one_of_disjunct BetS_R_Q_P).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_R_Q_P) as Col_R_Q_P.
 		pose proof (by_prop_Col_order _ _ _ Col_R_Q_P) as (Col_Q_R_P & Col_Q_P_R & Col_P_R_Q & Col_R_P_Q & Col_P_Q_R). (* wanted Col_Q_R_P *)
 		pose proof (by_prop_neq_symmetric _ _ neq_R_Q) as neq_Q_R.
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_Q_R_C Col_Q_R_P neq_Q_R) as Col_R_C_P.

--- a/lemma_planeseparation.v
+++ b/lemma_planeseparation.v
@@ -1,4 +1,7 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_C_B.
+Require Import ProofCheckingEuclid.by_def_Col_from_eq_B_C.
 Require Import ProofCheckingEuclid.by_def_OppositeSide.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_ABE_CDE.
@@ -54,7 +57,7 @@ Proof.
 	destruct OppositeSide_D_AB_E2 as (W & BetS_D_W_E & Col_A_B_W & _).
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_D_W_E) as (neq_W_E & neq_D_W & neq_D_E).
-	assert (Col D W E) as Col_D_W_E by (unfold Col; one_of_disjunct BetS_D_W_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_W_E) as Col_D_W_E.
 	pose proof (by_prop_Col_order _ _ _ Col_D_W_E) as (Col_W_D_E & Col_W_E_D & Col_E_D_W & Col_D_E_W & Col_E_W_D).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_D_W_E) as BetS_E_W_D.
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_W) as (Col_B_A_W & Col_B_W_A & Col_W_A_B & Col_A_W_B & Col_W_B_A).
@@ -64,8 +67,8 @@ Proof.
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_G_Q) as (neq_G_Q & neq_C_G & neq_C_Q).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_D_H_Q) as (neq_H_Q & neq_D_H & neq_D_Q).
-	assert (Col C G Q) as Col_C_G_Q by (unfold Col; one_of_disjunct BetS_C_G_Q).
-	assert (Col D H Q) as Col_D_H_Q by (unfold Col; one_of_disjunct BetS_D_H_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_G_Q) as Col_C_G_Q.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_H_Q) as Col_D_H_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_C_G_Q) as (Col_G_C_Q & Col_G_Q_C & Col_Q_C_G & Col_C_Q_G & Col_Q_G_C).
 	pose proof (by_prop_Col_order _ _ _ Col_D_H_Q) as (Col_H_D_Q & Col_H_Q_D & Col_Q_D_H & Col_D_Q_H & Col_Q_H_D).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_C_G_Q) as BetS_Q_G_C.
@@ -133,7 +136,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_Q_G_D) as (neq_G_D & _ & _).
 	pose proof (by_prop_neq_symmetric _ _ neq_G_D) as neq_D_G.
 
-	assert (Col Q G D) as Col_Q_G_D by (unfold Col; one_of_disjunct BetS_Q_G_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_Q_G_D) as Col_Q_G_D.
 	pose proof (by_prop_Col_order _ _ _ Col_Q_G_D) as (Col_G_Q_D & Col_G_D_Q & Col_D_Q_G & Col_Q_D_G & Col_D_G_Q).
 
 	assert (Col E D G \/ ~ Col E D G) as [Col_E_D_G|n_Col_E_D_G] by (apply Classical_Prop.classic).
@@ -359,7 +362,7 @@ Proof.
 	destruct OppositeSide_D_AB_E2 as (W & BetS_D_W_E & Col_A_B_W & _).
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_D_W_E) as (neq_W_E & neq_D_W & neq_D_E).
-	assert (Col D W E) as Col_D_W_E by (unfold Col; one_of_disjunct BetS_D_W_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_W_E) as Col_D_W_E.
 	pose proof (by_prop_Col_order _ _ _ Col_D_W_E) as (Col_W_D_E & Col_W_E_D & Col_E_D_W & Col_D_E_W & Col_E_W_D).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_D_W_E) as BetS_E_W_D.
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_W) as (Col_B_A_W & Col_B_W_A & Col_W_A_B & Col_A_W_B & Col_W_B_A).
@@ -369,8 +372,8 @@ Proof.
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_G_Q) as (neq_G_Q & neq_C_G & neq_C_Q).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_D_H_Q) as (neq_H_Q & neq_D_H & neq_D_Q).
-	assert (Col C G Q) as Col_C_G_Q by (unfold Col; one_of_disjunct BetS_C_G_Q).
-	assert (Col D H Q) as Col_D_H_Q by (unfold Col; one_of_disjunct BetS_D_H_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_G_Q) as Col_C_G_Q.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_H_Q) as Col_D_H_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_C_G_Q) as (Col_G_C_Q & Col_G_Q_C & Col_Q_C_G & Col_C_Q_G & Col_Q_G_C).
 	pose proof (by_prop_Col_order _ _ _ Col_D_H_Q) as (Col_H_D_Q & Col_H_Q_D & Col_Q_D_H & Col_D_Q_H & Col_Q_H_D).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_C_G_Q) as BetS_Q_G_C.
@@ -412,9 +415,9 @@ Proof.
 	pose proof (by_prop_neq_symmetric _ _ neq_C_H) as neq_H_C.
 	pose proof (by_prop_neq_symmetric _ _ neq_D_F) as neq_F_D.
 
-	assert (Col C F H) as Col_C_F_H by (unfold Col; one_of_disjunct BetS_C_F_H).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_F_H) as Col_C_F_H.
 	pose proof (by_prop_Col_order _ _ _ Col_C_F_H) as (Col_F_C_H & Col_F_H_C & Col_H_C_F & Col_C_H_F & Col_H_F_C).
-	assert (Col G F D) as Col_G_F_D by (unfold Col; one_of_disjunct BetS_G_F_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_G_F_D) as Col_G_F_D.
 	pose proof (by_prop_Col_order _ _ _ Col_G_F_D) as (Col_F_G_D & Col_F_D_G & Col_D_G_F & Col_G_D_F & Col_D_F_G).
 
 	assert (~ eq G H) as neq_G_H.
@@ -457,13 +460,13 @@ Proof.
 			pose proof (by_prop_Col_order _ _ _ Col_D_G_W) as (_ & Col_G_W_D & _ & _ & _).
 
 			assert (eq B B) as eq_B_B by (reflexivity).
-			assert (Col A B B) as Col_A_B_B by (unfold Col; one_of_disjunct eq_B_B).
+			pose proof (by_def_Col_from_eq_B_C A B B eq_B_B) as Col_A_B_B.
 
 			pose proof (by_prop_Col_ABC_ABD_ABE_CDE _ _ _ _ _ neq_A_B Col_A_B_G Col_A_B_W Col_A_B_B) as Col_G_W_B.
 			pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_G_W_D Col_G_W_B neq_G_W) as Col_W_D_B.
 
 			assert (eq A A) as eq_A_A by (reflexivity).
-			assert (Col B A A) as Col_B_A_A by (unfold Col; one_of_disjunct eq_A_A).
+			pose proof (by_def_Col_from_eq_B_C B A A eq_A_A) as Col_B_A_A.
 			pose proof (by_prop_Col_ABC_ABD_ABE_CDE _ _ _ _ _ neq_B_A Col_B_A_G Col_B_A_W Col_B_A_A) as Col_G_W_A.
 			pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_G_W_D Col_G_W_A neq_G_W) as Col_W_D_A.
 
@@ -492,7 +495,7 @@ Proof.
 			pose proof (by_prop_BetS_notequal _ _ _ BetS_D_F_E) as (neq_F_E & _ & _).
 			pose proof (by_prop_neq_symmetric _ _ neq_F_E) as neq_E_F.
 
-			assert (Col D F E) as Col_D_F_E by (unfold Col; one_of_disjunct BetS_D_F_E).
+			pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_F_E) as Col_D_F_E.
 			pose proof (by_prop_Col_order _ _ _ Col_D_F_E) as (_ & _ & _ & _ & Col_E_F_D).
 
 			pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_E_F_C Col_E_F_D neq_E_F) as Col_F_C_D.
@@ -519,7 +522,7 @@ Proof.
 		pose proof (axiom_betweennesssymmetry _ _ _ BetS_E_M_C) as BetS_C_M_E.
 		pose proof (by_prop_BetS_notequal _ _ _ BetS_H_G_M) as (_ & neq_H_G & _).
 
-		assert (Col H G M) as Col_H_G_M by (unfold Col; one_of_disjunct BetS_H_G_M).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_H_G_M) as Col_H_G_M.
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_H_G_M Col_H_G_B neq_H_G) as Col_G_M_B.
 		pose proof (by_prop_Col_order _ _ _ Col_G_M_B) as (_ & _ & _ & Col_G_B_M & _).
 
@@ -606,8 +609,8 @@ Proof.
 		pose proof (by_prop_BetS_notequal _ _ _ BetS_E_J_F) as (_ & _ & neq_E_F).
 		pose proof (by_prop_neq_symmetric _ _ neq_E_F) as neq_F_E.
 
-		assert (Col G J W) as Col_G_J_W by (unfold Col; one_of_disjunct BetS_G_J_W).
-		assert (Col E F J) as Col_E_F_J by (unfold Col; one_of_disjunct BetS_E_J_F).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_G_J_W) as Col_G_J_W.
+		pose proof (by_def_Col_from_BetS_A_C_B _ _ _ BetS_E_J_F) as Col_E_F_J.
 
 		pose proof (by_prop_Col_order _ _ _ Col_G_J_W) as (_ & _ & _ & Col_G_W_J & _).
 		pose proof (by_prop_Col_order _ _ _ Col_E_F_J) as (Col_F_E_J & _ & _ & _ & _).

--- a/lemma_s_intersecting_triangles_ncol_ADE.v
+++ b/lemma_s_intersecting_triangles_ncol_ADE.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
@@ -40,8 +41,8 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_B_F_E) as (neq_F_E & _ & _).
 	pose proof (by_prop_neq_symmetric _ _ neq_A_D) as neq_D_A.
 
-	assert (Col A F D) as Col_A_F_D by (unfold Col; one_of_disjunct BetS_A_F_D).
-	assert (Col B F E) as Col_B_F_E by (unfold Col; one_of_disjunct BetS_B_F_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_F_D) as Col_A_F_D.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_F_E) as Col_B_F_E.
 	pose proof (by_prop_Col_order _ _ _ Col_A_F_D) as (_ & Col_F_D_A & Col_D_A_F & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_B_F_E) as (_ & Col_F_E_B & _ & _ & _).
 
@@ -61,7 +62,7 @@ Proof.
 	{
 		intros BetS_A_D_E.
 
-		assert (Col A D E) as Col_A_D_E by (unfold Col; one_of_disjunct BetS_A_D_E).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_D_E) as Col_A_D_E.
 		pose proof (by_prop_Col_order _ _ _ Col_A_D_E) as (Col_D_A_E & _ & _ & _ & _).
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_D_A_E Col_D_A_F neq_D_A) as Col_A_E_F.
@@ -76,7 +77,7 @@ Proof.
 	assert (~ BetS A E D) as nBetS_A_E_D.
 	{
 		intros BetS_A_E_D.
-		assert (Col A E D) as Col_A_E_D by (unfold Col; one_of_disjunct BetS_A_E_D).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_E_D) as Col_A_E_D.
 
 		pose proof (by_prop_Col_order _ _ _ Col_A_E_D) as (_ & _ & Col_D_A_E & _ & _).
 
@@ -93,7 +94,7 @@ Proof.
 	{
 		intros BetS_D_A_E.
 
-		assert (Col D A E) as Col_D_A_E by (unfold Col; one_of_disjunct BetS_D_A_E).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_A_E) as Col_D_A_E.
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_D_A_E Col_D_A_F neq_D_A) as Col_A_E_F.
 		pose proof (by_prop_Col_order _ _ _ Col_A_E_F) as (_ & _ & _ & _ & Col_F_E_A).

--- a/lemma_s_intersecting_triangles_ncol_BDE.v
+++ b/lemma_s_intersecting_triangles_ncol_BDE.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
@@ -34,8 +35,8 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_F_D) as (neq_F_D & _ & _).
 	pose proof (by_prop_neq_symmetric _ _ neq_B_E) as neq_E_B.
 
-	assert (Col A F D) as Col_A_F_D by (unfold Col; one_of_disjunct BetS_A_F_D).
-	assert (Col B F E) as Col_B_F_E by (unfold Col; one_of_disjunct BetS_B_F_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_F_D) as Col_A_F_D.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_F_E) as Col_B_F_E.
 	pose proof (by_prop_Col_order _ _ _ Col_A_F_D) as (_ & Col_F_D_A & _ & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_B_F_E) as (_ & Col_F_E_B & Col_E_B_F & _ & _).
 
@@ -55,7 +56,7 @@ Proof.
 	{
 		intros BetS_B_D_E.
 
-		assert (Col B D E) as Col_B_D_E by (unfold Col; one_of_disjunct BetS_B_D_E).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_D_E) as Col_B_D_E.
 		pose proof (by_prop_Col_order _ _ _ Col_B_D_E) as (_ & _ & Col_E_B_D & _ & _).
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _  Col_E_B_D Col_E_B_F neq_E_B) as Col_B_D_F.
@@ -71,7 +72,7 @@ Proof.
 	{
 		intros BetS_B_E_D.
 
-		assert (Col B E D) as Col_B_E_D by (unfold Col; one_of_disjunct BetS_B_E_D).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_E_D) as Col_B_E_D.
 		pose proof (by_prop_Col_order _ _ _ Col_B_E_D) as (Col_E_B_D & _ & _ & _ & _).
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _  Col_E_B_D Col_E_B_F neq_E_B) as Col_B_D_F.
@@ -86,7 +87,7 @@ Proof.
 	{
 		intros BetS_D_B_E.
 
-		assert (Col D B E) as Col_D_B_E by (unfold Col; one_of_disjunct BetS_D_B_E).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_D_B_E) as Col_D_B_E.
 		pose proof (by_prop_Col_order _ _ _ Col_D_B_E) as (_ & _ & _ & _ & Col_E_B_D).
 
 		pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _  Col_E_B_D Col_E_B_F neq_E_B) as Col_B_D_F.

--- a/lemma_sameside_onray.v
+++ b/lemma_sameside_onray.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_OppositeSide.
 Require Import ProofCheckingEuclid.by_def_SameSide.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -43,7 +44,7 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_F_V_Q) as (_ & _ & neq_F_Q).
 	pose proof (by_prop_neq_symmetric _ _ neq_F_Q) as neq_Q_F.
 
-	assert (Col F V Q) as Col_F_V_Q by (unfold Col; one_of_disjunct BetS_F_V_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_F_V_Q) as Col_F_V_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_F_V_Q) as (_ & _ & Col_Q_F_V & _ & _).
 
 	pose proof (by_prop_nCol_distinct _ _ _ nCol_A_C_E) as (neq_A_C & _ & _ & neq_C_A & _ & _).

--- a/lemma_supplements_conga.v
+++ b/lemma_supplements_conga.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_CongA.
 Require Import ProofCheckingEuclid.by_def_OnRay.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -83,7 +84,7 @@ Proof.
 	pose proof (by_prop_neq_symmetric _ _ neq_B_F) as neq_F_B.
 
 	pose proof (by_prop_OnRay_impliescollinear _ _ _ OnRay_BC_D) as Col_B_C_D.
-	assert (Col A B F) as Col_A_B_F by (unfold Col; one_of_disjunct BetS_A_B_F).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_B_F) as Col_A_B_F.
 
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_F) as (_ & _ & _ & _ & Col_F_B_A).
 	pose proof (by_prop_Col_order _ _ _ Col_B_C_D) as (_ & _ & Col_D_B_C & _ & _).

--- a/lemma_twolines.v
+++ b/lemma_twolines.v
@@ -1,4 +1,6 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_B_A_C.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_ABD_BCD.
 Require Import ProofCheckingEuclid.by_prop_Col_ABC_BAC.
@@ -35,10 +37,10 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_E_D) as (_ & _ & neq_C_D).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_E_B) as (_ & _ & neq_A_B).
 
-	assert (Col A E B) as Col_A_E_B by (unfold Col; one_of_disjunct BetS_A_E_B).
-	assert (Col A F B) as Col_A_F_B by (unfold Col; one_of_disjunct BetS_A_F_B).
-	assert (Col C E D) as Col_C_E_D by (unfold Col; one_of_disjunct BetS_C_E_D).
-	assert (Col C F D) as Col_C_F_D by (unfold Col; one_of_disjunct BetS_C_F_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_E_B) as Col_A_E_B.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_F_B) as Col_A_F_B.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_E_D) as Col_C_E_D.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_F_D) as Col_C_F_D.
 
 	pose proof (by_prop_Col_order _ _ _ Col_A_E_B) as (_ & _ & _ & Col_A_B_E & _).
 	pose proof (by_prop_Col_order _ _ _ Col_A_F_B) as (_ & _ & _ & Col_A_B_F & _).
@@ -64,7 +66,7 @@ Proof.
 		{
 			intros eq_F_B.
 
-			assert (Col F C D) as Col_F_C_D by (unfold Col; one_of_disjunct BetS_C_F_D).
+			pose proof (by_def_Col_from_BetS_B_A_C _ _ _ BetS_C_F_D) as Col_F_C_D.
 			assert (Col B C D) as Col_B_C_D by (rewrite <- eq_F_B; exact Col_F_C_D).
 
 			contradict Col_B_C_D.

--- a/proposition_06a.v
+++ b/proposition_06a.v
@@ -1,4 +1,5 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_LtA.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_BetS_A_E_B.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
@@ -66,7 +67,7 @@ Proof.
 
 		pose proof (by_prop_BetS_notequal _ _ _ BetS_B_D_A) as (_ & neq_B_D & _).
 
-		assert (Col B D A) as Col_B_D_A by (unfold Col; one_of_disjunct BetS_B_D_A).
+		pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_D_A) as Col_B_D_A.
 		pose proof (by_prop_Col_order _ _ _ Col_B_D_A) as (_ & _ & _ & Col_B_A_D & _).
 
 		pose proof (by_def_OnRay_from_BetS_A_E_B _ _ _ BetS_B_D_A neq_B_A) as OnRay_BA_D.

--- a/proposition_07.v
+++ b/proposition_07.v
@@ -1,4 +1,6 @@
 Require Coq.Logic.Classical_Prop.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_B_A_C.
 Require Import ProofCheckingEuclid.by_def_OnRay.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_BetS_A_B_E.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
@@ -89,8 +91,8 @@ Proof.
 	pose proof (lemma_extension _ _ _ _ neq_B_A neq_A_B) as (J & BetS_B_A_J & Cong_AJ_AB).
 	pose proof (by_def_OnRay_from_BetS_A_B_E _ _ _ BetS_A_B_K neq_A_B) as OnRay_AB_K.
 	pose proof (by_def_OnRay_from_BetS_A_B_E _ _ _ BetS_B_A_J neq_B_A) as OnRay_BA_J.
-	assert (Col A B J) as Col_A_B_J by (unfold Col; one_of_disjunct BetS_B_A_J).
-	assert (Col B A K) as Col_B_A_K by (unfold Col; one_of_disjunct BetS_A_B_K).
+	pose proof (by_def_Col_from_BetS_B_A_C _ _ _ BetS_B_A_J) as Col_A_B_J.
+	pose proof (by_def_Col_from_BetS_B_A_C _ _ _ BetS_A_B_K) as Col_B_A_K.
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_J) as (Col_B_A_J & _ & _ & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_B_A_J) as (_ & _ & _ & _ & Col_J_A_B).
 	pose proof (by_prop_Col_order _ _ _ Col_B_A_K) as (Col_A_B_K & _ & _ & _ & _).

--- a/proposition_09.v
+++ b/proposition_09.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_CongA.
 Require Import ProofCheckingEuclid.by_def_InAngle.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
@@ -56,7 +57,7 @@ Proof.
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_B_F_E) as (_ & neq_B_F & _).
 
-	assert (Col B F E) as Col_B_F_E by (unfold Col; one_of_disjunct BetS_B_F_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_B_F_E) as Col_B_F_E.
 	pose proof (by_prop_Col_order _ _ _ Col_B_F_E) as (_ & _ & _ & Col_B_E_F & _).
 
 	pose proof (by_def_InAngle _ _ _ _ _ _ OnRay_AB_B OnRay_AC_E BetS_B_F_E) as InAngle_BAC_F.

--- a/proposition_10.v
+++ b/proposition_10.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
 Require Import ProofCheckingEuclid.by_prop_Cong_doublereverse.
@@ -40,8 +41,8 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_A_E) as (neq_A_E & _ & neq_C_E).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_B_D) as (_ & _ & neq_C_D).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_B_D) as (neq_B_D & _ & _).
-	assert (Col C A E) as Col_C_A_E by (unfold Col; one_of_disjunct BetS_C_A_E).
-	assert (Col C B D) as Col_C_B_D by (unfold Col; one_of_disjunct BetS_C_B_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_A_E) as Col_C_A_E.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_B_D) as Col_C_B_D.
 
 	pose proof (by_prop_Col_order _ _ _ Col_C_A_E) as (Col_A_C_E & _ & _ & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_C_B_D) as (Col_B_C_D & _ & _ & _ & _).

--- a/proposition_11.v
+++ b/proposition_11.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_RightTriangle.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
 Require Import ProofCheckingEuclid.by_prop_Col_order.
@@ -27,7 +28,7 @@ Proof.
 	pose proof (lemma_extension _ _ _ _ neq_A_C neq_A_C) as (E & BetS_A_C_E & Cong_CE_AC).
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_C_E) as (_ & _ & neq_A_E).
-	assert (Col A C E) as Col_A_C_E by (unfold Col; one_of_disjunct BetS_A_C_E).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_C_E) as Col_A_C_E.
 	pose proof (by_prop_Col_order _ _ _ Col_A_C_E) as (_ & _ & _ & Col_A_E_C & _).
 
 	pose proof (by_prop_Cong_doublereverse _ _ _ _ Cong_CE_AC) as (Cong_CA_EC & _).

--- a/proposition_12.v
+++ b/proposition_12.v
@@ -1,3 +1,5 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_eq_B_C.
 Require Import ProofCheckingEuclid.by_def_InCirc_within_radius.
 Require Import ProofCheckingEuclid.by_def_Perp_at.
 Require Import ProofCheckingEuclid.by_def_RightTriangle.
@@ -48,12 +50,12 @@ Proof.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_P_B_Q) as (neq_B_Q & _ & neq_P_Q).
 	pose proof (proposition_10 _ _ neq_P_Q) as (M & BetS_P_M_Q & Cong_MP_MQ).
 
-	assert (Col P M Q) as Col_P_M_Q by (unfold Col; one_of_disjunct BetS_P_M_Q).
-	assert (Col P B Q) as Col_P_B_Q by (unfold Col; one_of_disjunct BetS_P_B_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_P_M_Q) as Col_P_M_Q.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_P_B_Q) as Col_P_B_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_P_M_Q) as (_ & _ & _ & Col_P_Q_M & _).
 	pose proof (by_prop_Col_order _ _ _ Col_P_B_Q) as (_ & _ & _ & Col_P_Q_B & _).
 	pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_P_Q_B Col_P_Q_M neq_P_Q) as Col_Q_B_M.
-	assert (Col A B Q) as Col_A_B_Q by (unfold Col; one_of_disjunct BetS_A_B_Q).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_B_Q) as Col_A_B_Q.
 	pose proof (by_prop_Col_order _ _ _ Col_A_B_Q) as (_ & _ & _ & _ & Col_Q_B_A).
 	pose proof (by_prop_neq_symmetric _ _ neq_B_Q) as neq_Q_B.
 	pose proof (by_prop_Col_ABC_ABD_BCD _ _ _ _ Col_Q_B_M Col_Q_B_A neq_Q_B) as Col_B_M_A.
@@ -82,7 +84,7 @@ Proof.
 	) as RightTriangle_PMC.
 
 	assert (eq M M) as eq_M_M by (reflexivity).
-	assert (Col C M M) as Col_C_M_M by (unfold Col; one_of_disjunct eq_M_M).
+	pose proof (by_def_Col_from_eq_B_C C M M eq_M_M) as Col_C_M_M.
 
 	pose proof (
 		by_def_Perp_at

--- a/proposition_13.v
+++ b/proposition_13.v
@@ -1,3 +1,5 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_eq_B_C.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
 Require Import ProofCheckingEuclid.by_def_SumTwoRT.
 Require Import ProofCheckingEuclid.by_def_Supp.
@@ -26,7 +28,7 @@ Proof.
 
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_D_B_C) as (_ & neq_D_B & _).
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_D_B_C) as BetS_C_B_D.
-	assert (Col C B D) as Col_C_B_D by (unfold Col; one_of_disjunct BetS_C_B_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_B_D) as Col_C_B_D.
 
 	pose proof (by_prop_nCol_distinct _ _ _ nCol_A_B_C) as (_ & _ & _ & neq_B_A & _ & _).
 	pose proof (by_prop_nCol_order _ _ _ nCol_A_B_C) as (_ & _ & _ & _ & nCol_C_B_A).
@@ -34,7 +36,7 @@ Proof.
 	pose proof (by_def_OnRay_from_neq_A_B _ _ neq_B_A) as OnRay_BA_A.
 
 	assert (eq B B) as eq_B_B by (reflexivity).
-	assert (Col C B B) as Col_C_B_B by (unfold Col; one_of_disjunct eq_B_B).
+	pose proof (by_def_Col_from_eq_B_C C B B eq_B_B) as Col_C_B_B.
 
 	pose proof (by_prop_nCol_helper _ _ _ _ _ nCol_C_B_A Col_C_B_D Col_C_B_B neq_D_B) as nCol_D_B_A.
 	pose proof (by_prop_nCol_order _ _ _ nCol_D_B_A) as (_ & _ & _ & _ & nCol_A_B_D).

--- a/proposition_14.v
+++ b/proposition_14.v
@@ -1,3 +1,5 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
+Require Import ProofCheckingEuclid.by_def_Col_from_eq_B_C.
 Require Import ProofCheckingEuclid.by_def_SameSide.
 Require Import ProofCheckingEuclid.by_def_Supp.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -39,9 +41,9 @@ Proof.
 	pose proof (cn_congruencereflexive B D) as Cong_BD_BD.
 
 	assert (eq B B) as eq_B_B by (reflexivity).
-	assert (Col A B B) as Col_A_B_B by (unfold Col; one_of_disjunct eq_B_B).
-	assert (Col D B B) as Col_D_B_B by (unfold Col; one_of_disjunct eq_B_B).
-	assert (Col C B B) as Col_C_B_B by (unfold Col; one_of_disjunct eq_B_B).
+	pose proof (by_def_Col_from_eq_B_C A B B eq_B_B) as Col_A_B_B.
+	pose proof (by_def_Col_from_eq_B_C D B B eq_B_B) as Col_D_B_B.
+	pose proof (by_def_Col_from_eq_B_C C B B eq_B_B) as Col_C_B_B.
 
 	destruct SumTwoRT_ABC_DBE as (a & b & e & c & d & Supp_abc_dbe & CongA_ABC_abc & CongA_DBE_dbe).
 
@@ -62,7 +64,7 @@ Proof.
 
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_A_B_T) as BetS_T_B_A.
 
-	assert (Col A B T) as Col_A_B_T by (unfold Col; one_of_disjunct BetS_A_B_T).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_B_T) as Col_A_B_T.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_B_T) as (neq_B_T & _ & _).
 	pose proof (by_prop_neq_symmetric _ _ neq_B_T) as neq_T_B.
 	pose proof (by_prop_nCol_helper _ _ _ _ _ nCol_A_B_C Col_A_B_T Col_A_B_B neq_T_B) as nCol_T_B_C.

--- a/proposition_15.v
+++ b/proposition_15.v
@@ -1,3 +1,4 @@
+Require Import ProofCheckingEuclid.by_def_Col_from_BetS_A_B_C.
 Require Import ProofCheckingEuclid.by_def_OnRay_from_neq_A_B.
 Require Import ProofCheckingEuclid.by_def_Supp.
 Require Import ProofCheckingEuclid.by_prop_BetS_notequal.
@@ -33,8 +34,8 @@ Proof.
 	pose proof (axiom_betweennesssymmetry _ _ _ BetS_C_E_D) as BetS_D_E_C.
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_A_E_B) as (neq_E_B & _ & _).
 	pose proof (by_prop_BetS_notequal _ _ _ BetS_C_E_D) as (neq_E_D & _ & _).
-	assert (Col A E B) as Col_A_E_B by (unfold Col; one_of_disjunct BetS_A_E_B).
-	assert (Col C E D) as Col_C_E_D by (unfold Col; one_of_disjunct BetS_C_E_D).
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_A_E_B) as Col_A_E_B.
+	pose proof (by_def_Col_from_BetS_A_B_C _ _ _ BetS_C_E_D) as Col_C_E_D.
 	pose proof (by_prop_Col_order _ _ _ Col_A_E_B) as (Col_E_A_B & _ & _ & _ & _).
 	pose proof (by_prop_Col_order _ _ _ Col_C_E_D) as (Col_E_C_D & _ & _ & _ & _).
 


### PR DESCRIPTION
Use by_def_Col_from instead of one_of_disjunct

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/blin/proof-checking-euclid/pull/64).
* #65
* __->__ #64